### PR TITLE
Don't try to load job.args for started taks

### DIFF
--- a/doppler/service.py
+++ b/doppler/service.py
@@ -97,7 +97,7 @@ def get_job(request_id):
     last_retry = None
     retries_left = 0
 
-    if status != "done":
+    if status not in ("done", "started"):
         args = json.loads(job.args)
         taskid, fname, args, kwargs, run_at = args
         scheduled_at = kwargs['scheduled_at']


### PR DESCRIPTION
If you try query doppler for a job status, while inside the actual
callback of that job, `job.args` will be None. This simply returns the
status as being started and prevents a crash.